### PR TITLE
continuous integration

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,35 @@
+name: Lint & Test
+
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches: 
+      - master
+      
+
+jobs:
+  verify:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Check Lint
+      run: flake8
+    - name: Run Tests
+      run: pytest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-20.04]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v2
@@ -27,13 +27,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
       run: |
-        apt install pipenv
+        pip install pipenv
         pipenv install --dev
+        pipenv shell
     - name: Check Lint
       run: |
-        pipenv shell
         flake8
     - name: Run Tests
       run: |
-        pipenv shell
         pytest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,9 +27,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
       run: |
-        pip install pipenv
-        pipenv install --dev
-        pipenv shell
+        pip install -r requirements.ci.txt
     - name: Check Lint
       run: |
         flake8

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,6 +27,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
       run: |
+        apt install pipenv
         pipenv install --dev
     - name: Check Lint
       run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,10 +3,10 @@ name: Lint & Test
 on:
   push:
     branches: 
-      - master
+      - main
   pull_request:
     branches: 
-      - master
+      - main
       
 
 jobs:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,9 +27,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pipenv install --dev
     - name: Check Lint
-      run: flake8
+      run: |
+        pipenv shell
+        flake8
     - name: Run Tests
-      run: pytest
+      run: |
+        pipenv shell
+        pytest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-20.04]
-        python-version: [3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -1,0 +1,12 @@
+# requirements file needed by CI
+# dev-packages
+flake8 = "*"
+flake8-docstrings = "*"
+jupyter = "*"
+pep8-naming = "*"
+pytest = "*"
+requests = "*"
+# packages
+fastapi = "*"
+pandas = "*"
+uvicorn = "*"

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -1,12 +1,12 @@
 # requirements file needed by CI
 # dev-packages
-flake8 = "*"
-flake8-docstrings = "*"
-jupyter = "*"
-pep8-naming = "*"
-pytest = "*"
-requests = "*"
+flake8
+flake8-docstrings
+jupyter
+pep8-naming
+pytest
+requests
 # packages
-fastapi = "*"
-pandas = "*"
-uvicorn = "*"
+fastapi
+pandas
+uvicorn


### PR DESCRIPTION
- needed to add `requirements.ci.txt` because i couldn't get pipenv to work in github's CI container.
- runs on 3.6, 3.7, and 3.8 (in parallel)
- runs on pull request to `main` and on push to `main`. 